### PR TITLE
Pin GitHub Actions to commit SHAs

### DIFF
--- a/.github/workflows/jekyll.yml
+++ b/.github/workflows/jekyll.yml
@@ -32,7 +32,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - name: Setup Ruby
         # https://github.com/ruby/setup-ruby/releases/tag/v1.207.0
         uses: ruby/setup-ruby@4a9ddd6f338a97768b8006bf671dfbad383215f4
@@ -42,7 +42,7 @@ jobs:
           cache-version: 0 # Increment this number if you need to re-download cached gems
       - name: Setup Pages
         id: pages
-        uses: actions/configure-pages@v5
+        uses: actions/configure-pages@983d7736d9b0ae728b81ab479565c72886d7745b # v5
       - name: Build with Jekyll
         # Outputs to the './_site' directory by default
         run: bundle exec jekyll build --baseurl "${{ steps.pages.outputs.base_path }}"
@@ -50,7 +50,7 @@ jobs:
           JEKYLL_ENV: production
       - name: Upload artifact
         # Automatically uploads an artifact from the './_site' directory by default
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@56afc609e74202658d3ffba0e8f6dda462b719fa # v3
 
   # Deployment job
   deploy:
@@ -62,4 +62,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e # v4


### PR DESCRIPTION
Pins GitHub Actions `uses:` references in `mrecachinas/mrecachinas.github.io` to immutable commit SHAs.

## Summary

| Metric | Count |
| --- | ---: |
| Files changed | 1 |
| Files scanned | 1 |
| Refs found | 4 |
| Refs pinned | 4 |
| Skipped refs | 1 |
| Warnings | 0 |
| Errors | 0 |

## Why

Pinning actions to full commit SHAs prevents future tag or branch retargeting from changing workflow behavior without review.

## Reviewer notes

- Original refs are preserved in inline comments when possible.
- Pin comments use the Dependabot-compatible original-ref style.
- Branch refs are skipped by default unless `--allow-branch-pins` is used.
- No minimum action age was enforced for this run.

## Pinned refs

| Location | Before | After | Resolved as |
| --- | --- | --- | --- |
| `.github/workflows/jekyll.yml:35` | `actions/checkout@v4` | `actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5` | `tag` |
| `.github/workflows/jekyll.yml:45` | `actions/configure-pages@v5` | `actions/configure-pages@983d7736d9b0ae728b81ab479565c72886d7745b` | `tag` |
| `.github/workflows/jekyll.yml:53` | `actions/upload-pages-artifact@v3` | `actions/upload-pages-artifact@56afc609e74202658d3ffba0e8f6dda462b719fa` | `tag` |
| `.github/workflows/jekyll.yml:65` | `actions/deploy-pages@v4` | `actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e` | `tag` |

## Skipped refs

| Location | Ref | Reason |
| --- | --- | --- |
| `.github/workflows/jekyll.yml:38` | `ruby/setup-ruby@4a9ddd6f338a97768b8006bf671dfbad383215f4` | already pinned to a full SHA |

---

Generated by pinner 0.1.0.
